### PR TITLE
'ユーザー新規登録＆配信画面の修正_20241003'

### DIFF
--- a/app/Http/Controllers/User/Auth/RegisterController.php
+++ b/app/Http/Controllers/User/Auth/RegisterController.php
@@ -52,7 +52,7 @@ class RegisterController extends Controller
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
-            'name_kana' =>['required','string','max:255']
+            'name_kana' =>['required','string','max:255','katakana']
         ]);
     }
 

--- a/app/Http/Controllers/User/DeliveryController.php
+++ b/app/Http/Controllers/User/DeliveryController.php
@@ -21,7 +21,8 @@ class DeliveryController extends Controller
         $progressModel = new CurriculumProgress;
         $clear_flg = $progressModel -> getClearflg($id); //授業の受講状態の取得
 
-//ここから公開時間の処理
+//ここから公開時間の処理※常時公開フラグが0だった場合に処理
+        if($always_flg == 0){
 
         $TimeModel = new DeliveryTime;
         $deliveryTime = $TimeModel ->getDeliveryTime($id); //公開期間の取得
@@ -31,13 +32,16 @@ class DeliveryController extends Controller
 
         $startTime = $deliveryTime -> delivery_from;
         $endTime = $deliveryTime -> delivery_to;
+        }
         
-        if($always_flg == 1){
-            $display_flg = 1; //$display_flgが1の場合は公開
-        }elseif($startTime <= $now && $now <= $endTime){
+       //以下$display_flgが1の場合は公開,0の場合は非公開
+
+        if($always_flg == 1){ //常時公開フラグが１なら$display_flgは1
+            $display_flg = 1; 
+        }elseif($startTime <= $now && $now <= $endTime){ //配信期間が１なら$display_flgは1
             $display_flg = 1;  
         }else{
-            $display_flg = 0; //$display_flgが1の場合は非公開
+            $display_flg = 0; //それ以外なら$display_flgは0
         }
 
         return view('user.delivery',['curriculum'=>$curriculum, 'clear_flg'=>$clear_flg,'display_flg'=>$display_flg,]);

--- a/app/Models/CurriculumProgress.php
+++ b/app/Models/CurriculumProgress.php
@@ -11,6 +11,8 @@ class CurriculumProgress extends Model
 {
     use HasFactory;
 
+    protected $fillable = ['curriculums_id','users_id','clear_flg','created_at','updated_at'];
+
     public function getClearflg($id){
         $user_id = Auth::id();
         $query = DB::table('curriculum_progress')
@@ -23,11 +25,15 @@ class CurriculumProgress extends Model
     public function updateClearflg($id){
         $user_id = Auth::id();
 
-        DB::table('curriculum_progress')
-        -> where('curriculums_id', $id)
-        -> where('users_id', $user_id)
-        -> update([
-            'clear_flg' => 1,
-        ]);
+        CurriculumProgress::updateorCreate(
+            [
+                'curriculums_id' => $id,
+                'users_id'=> $user_id
+            ],
+            [
+                'clear_flg' => 1,   
+            ]
+            );
     }
+
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Validator;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Validator::extend('katakana', function ($attribute, $value, $parameters, $validator) {
+            return preg_match('/[ァ-ヴー|ｦ-ﾟ]+/u', $value);
+        });
     }
 }

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -150,6 +150,7 @@ return [
     'url' => 'The :attribute must be a valid URL.',
     'ulid' => 'The :attribute must be a valid ULID.',
     'uuid' => 'The :attribute must be a valid UUID.',
+    'katakana' => ':attributeはカタカナで入力してください。',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
（１）ユーザー新規登録画面
　　　①カタカナのバリデーションを追加
（２）ユーザー配信画面
　　　①受講処理をupdateメソッドからupdateorCreateメソッドに修正
　　　②常時配信フラグがonになっている場合、配信期間が設定されていなくても画面が表示されるよう修正
